### PR TITLE
Various fixes described in forum thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Files ignored by GIT version control
+
+# Build tool (and compiler) temporary output
+castle-engine-output
+
+# Unix executable
+toy-story-2-like-game
+# Windows executable
+toy-story-2-like-game.exe
+# Library files placed alongside Windows executable
+*.dll
+# Auto-updated by CGE tools when compiling Windows build
+castle-auto-generated-resources.res
+
+# May contain secret data (your Android keystore username and password)
+AndroidSigningProperties.txt

--- a/data/gameviewmain.castle-user-interface
+++ b/data/gameviewmain.castle-user-interface
@@ -42,6 +42,7 @@
                 "ExposeTransforms" : [
                 ],
                 "Name" : "Scene1",
+                "PreciseCollisions" : true,
                 "RenderOptions" : {
                   "$$ClassName" : "TCastleScene.TSceneRenderOptions"
                 },
@@ -2908,10 +2909,6 @@
                         "RenderOptions" : {
                           "$$ClassName" : "TCastleScene.TSceneRenderOptions"
                         },
-                        "RotationPersistent" : {
-                          "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 1.5707963705062866E+000
-                        },
                         "Url" : "castle-data:/sandystreedome-assets/SandyTreedome-submarine.glb",
                         "$Behaviors" : [
                           {
@@ -3728,16 +3725,6 @@
                         },
                         "Url" : "castle-data:/generalgame-assets/sandyparts/head.md3"
                       }
-                    ],
-                    "$Behaviors" : [
-                      {
-                        "$$ClassName" : "TCastleMeshCollider",
-                        "Name" : "MeshColliderSandy"
-                      },
-                      {
-                        "$$ClassName" : "TCastleRigidBody",
-                        "Name" : "RigidBodySandy"
-                      }
                     ]
                   },
                   {
@@ -3897,8 +3884,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -3939,8 +3926,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -3982,8 +3969,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4025,8 +4012,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4068,8 +4055,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4111,8 +4098,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4154,8 +4141,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4197,8 +4184,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4240,8 +4227,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4283,8 +4270,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -4326,8 +4313,8 @@
                         },
                         "RotationPersistent" : {
                           "$$ClassName" : "TCastleVector4RotationPersistent",
-                          "W" : 2.6430511474609375E+000,
-                          "Y" : 1.0000000000000000E+000
+                          "W" : 2.5982055664062500E+000,
+                          "Y" : -1.0000000000000000E+000
                         },
                         "ScalePersistent" : {
                           "$$ClassName" : "TCastleVector3Persistent",
@@ -6099,6 +6086,9 @@
         {
           "$$ClassName" : "TCastleThirdPersonNavigation",
           "AvatarHierarchy" : "AvatarTransform",
+          "ChangeTransformation" : "ctDirect",
+          "DistanceToAvatarTarget" : 1.0000000000000000E+001,
+          "MoveSpeed" : 1.0000000000000000E+001,
           "Name" : "ThirdPersonNavigation"
         }
       ],
@@ -6113,26 +6103,25 @@
         },
         "RotationPersistent" : {
           "$$ClassName" : "TCastleVector4RotationPersistent",
-          "W" : 2.6467120647430420E+000,
-          "X" : -2.0982680842280388E-002,
-          "Y" : 9.9445641040802002E-001,
-          "Z" : 1.0303498059511185E-001
+          "W" : 3.6816523075103760E+000,
+          "X" : 4.0454111993312836E-002,
+          "Y" : 9.9114799499511719E-001,
+          "Z" : 1.2644805014133453E-001
         },
         "ScalePersistent" : {
           "$$ClassName" : "TCastleVector3Persistent",
-          "X" : 9.9999994039535522E-001,
-          "Y" : 9.9999982118606567E-001
+          "X" : 9.9999994039535522E-001
         },
         "TranslationPersistent" : {
           "$$ClassName" : "TCastleVector3Persistent",
-          "X" : -1.7368736267089844E+001,
-          "Y" : 9.7157583236694336E+000,
-          "Z" : -3.7020885467529297E+001
+          "X" : 6.7401947021484375E+001,
+          "Y" : 1.0672984123229980E+001,
+          "Z" : 2.6851673126220703E+001
         }
       },
       "InternalDesignNavigations[dnFly]" : {
         "$$ClassName" : "TCastleWalkNavigationDesign",
-        "MoveSpeed" : 6.8129215240478516E+000,
+        "MoveSpeed" : 4.2986625671386719E+001,
         "Name" : ""
       },
       "InternalDesignNavigations[dnExamine]" : {


### PR DESCRIPTION
I'll post shortly an answer in https://forum.castle-engine.io/t/need-help-understanding-how-to-assign-a-transform-as-an-avatar-of-a-third-person-navigation-camera-after-following-instructions/1144/32 documenting this. Summary:

- removed wrong 2nd navigation instance class and 2 variables
- working ThirdPersonNavigation.OnAnimation sample
- fix AvatarTransform.Orientation
- call ThirdPersonNavigation.Init
- adjust ThirdPersonNavigation collision parameters
- set Scene1.PreciseCollisions to true
- remove rigid body and collider from AvatarTransform
- add missing .gitignore